### PR TITLE
Fix speaker parsing and ensure tests import modules

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration for repository.
+
+Ensures the repository root is importable when tests are executed from the
+`tests` directory.
+"""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/ingest/parser.py
+++ b/ingest/parser.py
@@ -10,7 +10,14 @@ SCHEMA = json.loads(Path(SCHEMA_PATH).read_text())
 # Patterns for headings, timestamps, speakers, and procedures
 TIME_RE = re.compile(r"\[(\d{1,2})\.(\d{2})\s*(a\.m\.|p\.m\.)\]", re.IGNORECASE)
 HEADING_RE = re.compile(r"^[A-Z][A-Z '’\-\u2013\u2014&]+$")  # crude but works for Hansard headings
-SPEAKER_LINE_RE = re.compile(r"^([A-Z][a-z'.\- ]+)\s+\(([A-Za-z ]+)\s*-\s*([^)]+)\)\s*-\s*(.*)$")
+# The original expression for speaker lines assumed that surnames were
+# capitalised "normally" (e.g. "Smith"), which fails for Hansard's
+# convention of printing surnames in full caps (e.g. "Mr ROCKLIFF").
+# Relax the pattern to accept any combination of upper/lower case letters
+# after the first character so lines such as "Mr ROCKLIFF ..." are matched.
+SPEAKER_LINE_RE = re.compile(
+    r"^([A-Z][A-Za-z'.\- ]+)\s+\(([A-Za-z ]+)\s*-\s*([^)]+)\)\s*-\s*(.*)$"
+)
 SPEAKER_SIMPLE_RE = re.compile(r"^([A-Z][A-Za-z'.\- ]+)\s*-\s*(.*)$")
 PROCEDURE_LINES = [
     "Motion agreed to.",


### PR DESCRIPTION
## Summary
- relax speaker regex to handle fully-capitalised surnames
- add conftest to put repo root on sys.path for tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b65a0c7e388332881d169a0191aa3b